### PR TITLE
Switch from chrono to jiff for cross-compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 thiserror = "1"
-# Default features disabled to avoid iana-time-zone, which links CoreFoundation
-# on macOS and breaks cross-compilation from Linux via cargo-zigbuild.
-# We use Utc instead of Local timestamps as a tradeoff.
-chrono = { version = "0.4", default-features = false, features = ["std", "now", "clock"] }
+# jiff is used for timestamps - it reads /etc/localtime on Unix instead of
+# linking CoreFoundation (like chrono does via iana-time-zone), which allows
+# cross-compilation from Linux via cargo-zigbuild.
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/output.rs
+++ b/src/output.rs
@@ -78,17 +78,17 @@ pub fn format_prefix(
 
 /// Format a timestamp using the given format string.
 /// The format string uses Unicode date field symbols (like concurrently),
-/// which are converted to chrono's strftime format.
+/// which are converted to strftime format for jiff.
 fn format_timestamp(format: &str) -> String {
-    let chrono_format = unicode_to_chrono_format(format);
-    chrono::Local::now().format(&chrono_format).to_string()
+    let strftime_format = unicode_to_strftime_format(format);
+    jiff::Zoned::now().strftime(&strftime_format).to_string()
 }
 
-/// Convert a Unicode date format string to chrono's strftime format.
+/// Convert a Unicode date format string to strftime format.
 /// Supports the most common patterns used by concurrently.
 ///
 /// Unicode reference: <https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table>
-fn unicode_to_chrono_format(format: &str) -> String {
+fn unicode_to_strftime_format(format: &str) -> String {
     let mut result = String::with_capacity(format.len() * 2);
     let chars: Vec<char> = format.chars().collect();
     let mut i = 0;
@@ -120,8 +120,8 @@ fn unicode_to_chrono_format(format: &str) -> String {
             count += 1;
         }
 
-        // Convert Unicode pattern to chrono format
-        let chrono_pattern = match (c, count) {
+        // Convert Unicode pattern to strftime format
+        let strftime_pattern = match (c, count) {
             // Year
             ('y', 4) | ('Y', 4) => "%Y",
             ('y', 2) | ('Y', 2) => "%y",
@@ -173,13 +173,13 @@ fn unicode_to_chrono_format(format: &str) -> String {
             }
         };
 
-        // Handle fractional seconds specially - chrono uses %.Nf which outputs "0.NNN"
+        // Handle fractional seconds specially - jiff uses %.Nf which outputs "0.NNN"
         // We want just "NNN" like Unicode SSS
         if c == 'S' {
             // We'll handle this specially in the final output
             result.push_str("%3f");
         } else {
-            result.push_str(chrono_pattern);
+            result.push_str(strftime_pattern);
         }
         i += count;
     }


### PR DESCRIPTION
## Problem

The release build was failing on CI when cross-compiling for macOS from Linux via cargo-zigbuild:

```
error: unable to find framework 'CoreFoundation'. searched paths: none
```

This was caused by chrono's `clock` feature pulling in `iana-time-zone`, which links CoreFoundation on macOS.

## Solution

Switch from `chrono` to `jiff` (by BurntSushi) for date/time handling.

jiff reads `/etc/localtime` on Unix instead of calling system APIs, so it works correctly when cross-compiling. It also has zero transitive dependencies on Unix.

## Benefits

- ✅ Local time support (not UTC like a workaround would require)
- ✅ No CoreFoundation linking on macOS  
- ✅ Cross-compilation from Linux works
- ✅ Zero transitive dependencies on Unix
- ✅ Modern, well-maintained library by the author of ripgrep